### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,9 +7,9 @@ Package	KEYWORD2
 Sentinel	KEYWORD2
 Other	KEYWORD2
 All	KEYWORD2
-LogLevel KEYWORD1
-SenderType KEYWORD1
-DescriptorType KEYWORD1
+LogLevel	KEYWORD1
+SenderType	KEYWORD1
+DescriptorType	KEYWORD1
 MemberInfo	KEYWORD1
 getSentinelName	KEYWORD2
 getPackageName	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords